### PR TITLE
inject services in commands

### DIFF
--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -6,10 +6,16 @@
 
     <services>
         <service id="jms_translation.command.extract" class="JMS\TranslationBundle\Command\ExtractTranslationCommand" public="false">
+            <argument type="service" id="jms_translation.config_factory" />
+            <argument type="service" id="jms_translation.updater" />
+            <argument>%jms_translation.locales%</argument>
             <tag name="console.command" command="translation:extract" />
         </service>
 
         <service id="jms_translation.command.list_resources" class="JMS\TranslationBundle\Command\ResourcesListCommand" public="false">
+            <argument>%kernel.project_dir%</argument>
+            <argument>%translator.default_path%</argument>
+            <argument>%kernel.bundles%</argument>
             <tag name="console.command" command="translation:list-resources" />
         </service>
     </services>


### PR DESCRIPTION
Commands no longer make the container available. dependencies must be injected.

this would work with https://github.com/prolixtechnikos/JMSTranslationBundle/pull/1 ping @Guite in order to help make this compatible with Symfony 5. (although there may be some conflicts with that branch also)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (don't know how this works with Sf3 or 4)
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | 
| License       | Apache2
